### PR TITLE
force slowdown instead of pausing

### DIFF
--- a/Source/SomeThingsFloat/FloatingThings_MapComponent.cs
+++ b/Source/SomeThingsFloat/FloatingThings_MapComponent.cs
@@ -1255,7 +1255,7 @@ public class FloatingThings_MapComponent : MapComponent
 
                     if (notify && pawn.Faction?.IsPlayer == true)
                     {
-                        Find.TickManager.TogglePaused();
+                        Find.TickManager.slower.SignalForceNormalSpeed();
                         Messages.Message("STF.PawnIsDrowning".Translate(pawn.NameFullColored), pawn,
                             MessageTypeDefOf.ThreatBig);
                     }


### PR DESCRIPTION
Pausing is inconsistent with other similar events (e.g. attacked and downed by a hunting predator).

I can make this configurable if you insist.
