### PR TITLE
process terrain only for changed cells

### DIFF
--- a/Source/SomeThingsFloat/SomeThingsFloat.csproj
+++ b/Source/SomeThingsFloat/SomeThingsFloat.csproj
@@ -24,6 +24,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <Publicize Include="Assembly-CSharp" />
+    <Publicize Include="Assembly-CSharp" IncludeCompilerGeneratedMembers="false"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
MapEvents has TerrainChanged action, so there's no need to process all cells every time. Reduces 40ms (Ryzen 5 8600G) to practically nothing. And yes, this is on top of my ocean PR, because otherwise they'd conflict.

That's said, and I realized this only while finishing the patch, it's a question if this even matters (both this PR and your parallelization). Less than 100 ms per long tick should be basically negligible, that's few frames lost per a long time. So up to you.
