### PR TITLE
do not remove a pawn from a lord when losing footing

### DIFF
--- a/Source/SomeThingsFloat/HarmonyPatches/Lord_Notify_PawnLost.cs
+++ b/Source/SomeThingsFloat/HarmonyPatches/Lord_Notify_PawnLost.cs
@@ -1,0 +1,23 @@
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.AI.Group;
+
+namespace SomeThingsFloat;
+
+// Do not remove a pawn from a lord when losing footing, that causes e.g. raiders
+// be removed from a raid, and it also counts as them being lost (and thus counts
+// towards the entire group starting to flee), even though they'll most likely
+// get up to feet again quickly. Do this only for incapacitations, killing should
+// of course count.
+[HarmonyPatch(typeof(Lord), nameof(Lord.Notify_PawnLost))]
+public static class Lord_Notify_PawnLost
+{
+    public static bool Prefix(PawnLostCondition cond, DamageInfo? dinfo)
+    {
+        if(cond == PawnLostCondition.Incapped && Pawn_HealthTracker_MakeDowned.downedByLostFooting)
+            return false;
+        return true;
+    }
+}

--- a/Source/SomeThingsFloat/HarmonyPatches/Pawn_HealthTracker_MakeDowned.cs
+++ b/Source/SomeThingsFloat/HarmonyPatches/Pawn_HealthTracker_MakeDowned.cs
@@ -1,0 +1,20 @@
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace SomeThingsFloat;
+
+[HarmonyPatch(typeof(Pawn_HealthTracker), nameof(Pawn_HealthTracker.MakeDowned))]
+public static class Pawn_HealthTracker_MakeDowned
+{
+    public static bool downedByLostFooting = false;
+    public static void Prefix(Hediff hediff)
+    {
+        downedByLostFooting = hediff.def == HediffDefOf.STF_LostFooting;
+    }
+    public static void Postfix()
+    {
+        downedByLostFooting = false;
+    }
+}


### PR DESCRIPTION
That causes e.g. raiders be removed from a raid, and it also counts as them being lost (and thus counts towards the entire group starting to flee), even though they'll most likely get up to feet again quickly. Do this only for incapacitations, killing should of course count.

I've had a pigskins raid, and due to their trotter hands[1] they ended up fleeing before they made it across a larger body of water.

[1] Possibly it'd make more sense to use (manipulation+moving)/2 rather than just manipulation? Legs count in water too :).
