### PR TITLE
do not immediately drop inventory when losing footing

### DIFF
--- a/1.6/Defs/HediffDefs/Drowning.xml
+++ b/1.6/Defs/HediffDefs/Drowning.xml
@@ -2,7 +2,7 @@
 <Defs>
   <HediffDef>
     <defName>STF_Drowning</defName>
-    <hediffClass>SomeThingsFloat.Hediff_OnlyFloating</hediffClass>
+    <hediffClass>SomeThingsFloat.Hediff_Drowning</hediffClass>
     <label>drowning</label>
     <description>Pawn is struggling to keep above the water and is risking drowning.</description>
     <lethalSeverity>1</lethalSeverity>

--- a/1.6/Defs/HediffDefs/Drowning.xml
+++ b/1.6/Defs/HediffDefs/Drowning.xml
@@ -4,7 +4,7 @@
     <defName>STF_Drowning</defName>
     <hediffClass>SomeThingsFloat.Hediff_OnlyFloating</hediffClass>
     <label>drowning</label>
-    <description>Pawn is struggeling to keep above the water and is risking drowning.</description>
+    <description>Pawn is struggling to keep above the water and is risking drowning.</description>
     <lethalSeverity>1</lethalSeverity>
     <defaultLabelColor>(0.5, 0.6, 0.85)</defaultLabelColor>
     <stages>

--- a/Source/SomeThingsFloat/HarmonyPatches/Pawn_DropAndForbidEverything.cs
+++ b/Source/SomeThingsFloat/HarmonyPatches/Pawn_DropAndForbidEverything.cs
@@ -1,0 +1,24 @@
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace SomeThingsFloat;
+
+[HarmonyPatch(typeof(Pawn), nameof(Pawn.DropAndForbidEverything))]
+public static class Pawn_DropAndForbidEverything
+{
+    public static bool Prefix()
+    {
+        // Losing footing even only temporarily would normally result
+        // in dropping all inventory, which is annoying and problematic:
+        // Colonists would require picking everything up manually (since it's
+        // forbidden), friendly traders would spill their goods and not collect
+        // them, and raiders would disarm themselves. So do not drop inventory
+        // immediately after losing footing, Hediff_Drowning will possibly
+        // do it later.
+        if(Pawn_HealthTracker_MakeDowned.downedByLostFooting)
+            return false;
+        return true;
+    }
+}

--- a/Source/SomeThingsFloat/Hediff_Drowning.cs
+++ b/Source/SomeThingsFloat/Hediff_Drowning.cs
@@ -1,0 +1,25 @@
+using Verse;
+
+namespace SomeThingsFloat;
+
+public class Hediff_Drowning : Hediff_OnlyFloating
+{
+    public bool inventoryDropped;
+
+    public override void ExposeData()
+    {
+        base.ExposeData();
+        Scribe_Values.Look(ref inventoryDropped, "inventoryDropped", false);
+    }
+
+    public override void Tick()
+    {
+        base.Tick();
+        // See Pawn_DropAndForbidEverything.
+        if( Severity >= def.stages[1].minSeverity ) // 'serious' drowning, 0.5 severity
+        {
+            inventoryDropped = true;
+            pawn.DropAndForbidEverything();
+        }
+    }
+}


### PR DESCRIPTION
 It is annoying and problematic: Colonists would require picking everything up manually (since it's forbidden), friendly traders would spill their goods and not collect them, and raiders would disarm themselves. Drop inventory only when the drowning becomes serious.

Also, during testing of this I have noticed that it is actually extremely difficult for a conscious pawn to drown. Manipulation limited to at least 0.5 ( https://github.com/emipa606/SomeThingsFloat/blob/main/Source/SomeThingsFloat/FloatingThings_MapComponent.cs#L1092 ) means that pawns have 50% chance every time to get up, even when in terrible shape. Also the nimble check does not do what the description says, it simply gives another 50% chance regardless. Is this intentional? If yes, it seems more like an annoying much-ado-for-nothing feature, as all those warnings about desperate help mean nothing in practice.
