### PR TITLE
prevent downed pawns from crawling into water where they would drown

### DIFF
--- a/1.6/Defs/HediffDefs/Drowning.xml
+++ b/1.6/Defs/HediffDefs/Drowning.xml
@@ -7,6 +7,8 @@
     <description>Pawn is struggling to keep above the water and is risking drowning.</description>
     <lethalSeverity>1</lethalSeverity>
     <defaultLabelColor>(0.5, 0.6, 0.85)</defaultLabelColor>
+    <blocksSleeping>true</blocksSleeping>
+    <preventsCrawling>true</preventsCrawling>
     <stages>
       <li>
         <label>initial</label>

--- a/1.6/Defs/HediffDefs/LostFooting.xml
+++ b/1.6/Defs/HediffDefs/LostFooting.xml
@@ -7,6 +7,8 @@
     <description>The pawn has lost their footing in the moving water and is now trying to stay afloat</description>
     <lethalSeverity>9999</lethalSeverity>
     <isBad>false</isBad>
+    <blocksSleeping>true</blocksSleeping>
+    <preventsCrawling>true</preventsCrawling>
     <comps>
       <li Class="HediffCompProperties_SeverityPerDay">
         <severityPerDay>-5</severityPerDay>

--- a/Source/SomeThingsFloat/FloatingThings_MapComponent.cs
+++ b/Source/SomeThingsFloat/FloatingThings_MapComponent.cs
@@ -1241,7 +1241,7 @@ public class FloatingThings_MapComponent : MapComponent
                 SomeThingsFloat.PawnsThatBreathe?.Contains(pawn.def) == false ||
                 SomeThingsFloat.AquaticRaces.Contains(pawn.def) ||
                 SomeThingsFloat.Vehicles.Contains(pawn.def) ||
-                !pawn.Downed || !pawn.Awake())
+                !pawn.Downed)
             {
                 return;
             }

--- a/Source/SomeThingsFloat/FloatingThings_MapComponent.cs
+++ b/Source/SomeThingsFloat/FloatingThings_MapComponent.cs
@@ -61,6 +61,8 @@ public class FloatingThings_MapComponent : MapComponent
     private List<Thing> updateValuesValues;
     public int WastePacksFloated;
 
+    public bool IsCellWithWater(IntVec3 cell) => cellsWithWater.Any() && cellsWithWater.Contains(cell);
+
     public FloatingThings_MapComponent(Map map) : base(map)
     {
         SomeThingsFloat.FloatingMapComponents[map] = this;

--- a/Source/SomeThingsFloat/FloatingThings_MapComponent.cs
+++ b/Source/SomeThingsFloat/FloatingThings_MapComponent.cs
@@ -1237,11 +1237,7 @@ public class FloatingThings_MapComponent : MapComponent
                 return;
             }
 
-            if (pawn.Dead ||
-                SomeThingsFloat.PawnsThatBreathe?.Contains(pawn.def) == false ||
-                SomeThingsFloat.AquaticRaces.Contains(pawn.def) ||
-                SomeThingsFloat.Vehicles.Contains(pawn.def) ||
-                !pawn.Downed)
+            if (!SomeThingsFloat.CanDrown(pawn))
             {
                 return;
             }
@@ -1270,15 +1266,11 @@ public class FloatingThings_MapComponent : MapComponent
                 }
             }
 
-            var cannotDrown =
-                pawn.apparel?.WornApparel?.Any(apparel =>
-                    SomeThingsFloat.ApparelThatPreventDrowning.Contains(apparel.def)) == true || !pawn.HarmedByVacuum;
-
             var isSwimming = pawn.CurJobDef == JobDefOf.GoSwimming;
 
             if (drowningHediff != null)
             {
-                if (cannotDrown || inShallowWater || isSwimming)
+                if (inShallowWater || isSwimming)
                 {
                     toClearDrowning.Enqueue(pawn);
                     return;
@@ -1289,7 +1281,7 @@ public class FloatingThings_MapComponent : MapComponent
             }
             else
             {
-                if (cannotDrown || inShallowWater || isSwimming)
+                if (inShallowWater || isSwimming)
                 {
                     return;
                 }

--- a/Source/SomeThingsFloat/HarmonyPatches/Pawn_PathFollower_SetupMoveIntoNextCell.cs
+++ b/Source/SomeThingsFloat/HarmonyPatches/Pawn_PathFollower_SetupMoveIntoNextCell.cs
@@ -1,0 +1,58 @@
+using HarmonyLib;
+using RimWorld;
+using Verse;
+using Verse.AI;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SomeThingsFloat;
+
+// Prevent downed pawns from crawling into water where they would drown.
+[HarmonyPatch(typeof(Pawn_PathFollower), nameof(Pawn_PathFollower.SetupMoveIntoNextCell))]
+public static class Pawn_PathFollower_SetupMoveIntoNextCell
+{
+    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        bool found = false;
+        foreach(CodeInstruction instr in instructions)
+        {
+            yield return instr;
+            if(instr.opcode == OpCodes.Call && instr.operand.ToString().Contains("WalkableBy"))
+            {
+                yield return new CodeInstruction(OpCodes.Ldarg_0);
+                yield return new CodeInstruction(OpCodes.Call, typeof(Pawn_PathFollower_SetupMoveIntoNextCell)
+                    .GetMethod(nameof(Hook)));
+                found = true;
+            }
+        }
+        if(!found)
+            Log.Error("SomeThingsFloat: Could not patch Pawn_PathFollower.SetupMoveIntoNextCell()");
+    }
+
+    public static bool Hook(bool result, Pawn_PathFollower pather)
+    {
+        if (!SomeThingsFloatMod.Instance.Settings.DownedPawnsDrown)
+            return result;
+        if (!result)
+            return false;
+        Pawn pawn = pather.pawn;
+        IntVec3 nextCell = pather.nextCell;
+        if (!pawn.Downed)
+            return true;
+        if (!SomeThingsFloat.CanDrown(pawn))
+            return true;
+        if (!nextCell.IsValid || nextCell == pawn.Position)
+            return true;
+        if (!SomeThingsFloat.FloatingMapComponents.TryGetValue(pawn.Map, out var component))
+            return true;
+        if (!component.IsCellWithWater(nextCell))
+            return true;
+        if (SomeThingsFloat.ShallowTerrainDefs.Contains(nextCell.GetTerrain(pawn.Map)))
+            return true;
+        // Need to reset nextCell to pawn.Position, since the next pathing attempt starts from nextCell.
+        // The next path selected will presumably be the same, so this will happen once a tick.
+        pather.ResetToCurrentPosition();
+        return false;
+    }
+}

--- a/Source/SomeThingsFloat/SomeThingsFloat.cs
+++ b/Source/SomeThingsFloat/SomeThingsFloat.cs
@@ -125,6 +125,23 @@ public static class SomeThingsFloat
     }
 
 
+    public static bool CanDrown(Pawn pawn)
+    {
+        if (pawn.Dead || !pawn.Downed ||
+            SomeThingsFloat.PawnsThatBreathe?.Contains(pawn.def) == false ||
+            SomeThingsFloat.AquaticRaces.Contains(pawn.def) ||
+            SomeThingsFloat.Vehicles.Contains(pawn.def))
+        {
+            return false;
+        }
+        if (pawn.apparel?.WornApparel?.Any(apparel =>
+                SomeThingsFloat.ApparelThatPreventDrowning.Contains(apparel.def)) == true || !pawn.HarmedByVacuum)
+        {
+            return false;
+        }
+        return true;
+    }
+
     public static float GetFloatingValue(Thing thing)
     {
         var actualThing = thing;


### PR DESCRIPTION
When downed pawns try to crawl to bed, they should not crawl into water. Unfortunately I don't see a reasonable way to patch CanReach() to avoid that, so instead this patches the crawling itself to stop if the next tile would be dangerous (which will be most likely restarted next tick and stopped again repeatedly, but that doesn't seem to be a problem in practice).

Also includes some tiny fixes related to sleeping in water.

